### PR TITLE
Use Router to route JAX-RS Resources

### DIFF
--- a/ms-common-impl/src/main/java/net/trajano/ms/vertx/VertxConfig.java
+++ b/ms-common-impl/src/main/java/net/trajano/ms/vertx/VertxConfig.java
@@ -11,10 +11,14 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import net.trajano.ms.engine.internal.spring.SpringConfiguration;
+import net.trajano.ms.engine.jaxrs.JaxRsRouter;
 
 @Configuration
 @ComponentScan
-@ComponentScan(basePackageClasses = SpringConfiguration.class)
+@ComponentScan(basePackageClasses = {
+    SpringConfiguration.class,
+    JaxRsRouter.class
+})
 public class VertxConfig {
 
     @Value("${http.client.proxy.host:#{null}}")

--- a/ms-common-impl/src/main/java/net/trajano/ms/vertx/VertxMicroserviceEngine.java
+++ b/ms-common-impl/src/main/java/net/trajano/ms/vertx/VertxMicroserviceEngine.java
@@ -10,6 +10,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.ws.rs.core.Response.Status;
 
+import net.trajano.ms.engine.jaxrs.JaxRsRouter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +59,9 @@ public class VertxMicroserviceEngine implements
 
     @Autowired
     private VertxOptions vertxOptions;
+
+    @Autowired
+    private JaxRsRouter jaxRsRouter;
 
     /**
      * Sets the system properties and sets up the logger. {@inheritDoc}
@@ -116,7 +120,11 @@ public class VertxMicroserviceEngine implements
             CachedDataProvider.class,
             JwksRouteHandler.class,
             CommonMsJaxRs.class);
-        handlerStack.push(SpringJaxRsHandler.registerToRouter(router, applicationContext, Microservice.getApplicationClass()));
+        SpringJaxRsHandler springJaxRsHandler = new SpringJaxRsHandler(applicationContext, Microservice.getApplicationClass());
+
+        jaxRsRouter.register(Microservice.getApplicationClass(), router, springJaxRsHandler);
+
+        handlerStack.push(springJaxRsHandler);
 
         final Handler<RoutingContext> jwksRouteHandler = applicationContext.getBean(JwksRouteHandler.class);
 

--- a/ms-engine-spring-jaxrs/pom.xml
+++ b/ms-engine-spring-jaxrs/pom.xml
@@ -42,11 +42,21 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.11</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/ms-engine-spring-jaxrs/pom.xml
+++ b/ms-engine-spring-jaxrs/pom.xml
@@ -7,4 +7,51 @@
     <version>1.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>ms-engine-spring-jaxrs</artifactId>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>${vertx.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsFailureHandler.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsFailureHandler.java
@@ -1,0 +1,61 @@
+package net.trajano.ms.engine.jaxrs;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+
+public class JaxRsFailureHandler implements
+    Handler<RoutingContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JaxRsFailureHandler.class);
+
+    private static void sendErrorResponse(final RoutingContext context,
+        final WebApplicationException webAppException) {
+
+        context.response().setStatusCode(webAppException.getResponse().getStatus());
+        context.response().setStatusMessage(webAppException.getResponse().getStatusInfo().getReasonPhrase());
+        if (context.request().method() != HttpMethod.HEAD) {
+            if (webAppException.getResponse().getMediaType() == null) {
+                context.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+            } else {
+                context.response().putHeader(HttpHeaders.CONTENT_TYPE, webAppException.getResponse().getMediaType().toString());
+            }
+            context.response().end(webAppException.getResponse().getStatusInfo().getReasonPhrase());
+        }
+    }
+
+    @Override
+    public void handle(final RoutingContext context) {
+
+        final Throwable wae = context.failure();
+        if (wae instanceof ClientErrorException) {
+            // Use a lower level of logging when it is a client error exception
+            final WebApplicationException webAppException = (WebApplicationException) wae;
+            LOG.debug(wae.getMessage(), wae);
+            sendErrorResponse(context, webAppException);
+        } else if (wae instanceof WebApplicationException) {
+            final WebApplicationException webAppException = (WebApplicationException) wae;
+            LOG.error(wae.getMessage(), wae);
+            sendErrorResponse(context, webAppException);
+        } else {
+            LOG.error(wae.getMessage(), wae);
+            context.response().setStatusCode(500);
+            context.response().setStatusMessage(Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
+            if (context.request().method() != HttpMethod.HEAD) {
+                context.response().putHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+                context.response().end(Status.INTERNAL_SERVER_ERROR.getReasonPhrase());
+            }
+        }
+
+    }
+
+}

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
@@ -1,8 +1,11 @@
 package net.trajano.ms.engine.jaxrs;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.vertx.core.http.HttpMethod;
 
 public class JaxRsPath implements
     Comparable<JaxRsPath> {
@@ -13,40 +16,28 @@ public class JaxRsPath implements
      */
     private final String[] consumes;
 
-    private final boolean delete;
-
     private final boolean exact;
 
     /**
-     * Flag for GET and HEAD requests.
+     * VertX HTTP method.
      */
-    private final boolean get;
+    private final HttpMethod method;
 
     private final String path;
 
     private final String pathRegex;
 
-    private final boolean post;
-
     private final String[] produces;
-
-    private final boolean put;
 
     public JaxRsPath(final String path,
         final String[] consumes,
         final String[] produces,
-        final boolean get,
-        final boolean post,
-        final boolean put,
-        final boolean delete) {
+        final HttpMethod method) {
 
         this.path = path;
         this.consumes = consumes;
         this.produces = produces;
-        this.get = get;
-        this.post = post;
-        this.put = put;
-        this.delete = delete;
+        this.method = method;
         final Pattern placeholderPattern = Pattern.compile("/\\{([^}]+)}");
         final Pattern regexPlaceholderPattern = Pattern.compile("[-A-Za-z_0-9]+:\\s*(.+)");
         final Matcher matcher = placeholderPattern.matcher(path);
@@ -97,44 +88,28 @@ public class JaxRsPath implements
         if (!Arrays.equals(consumes, other.consumes)) {
             return false;
         }
-        if (delete != other.delete) {
+        if (method != other.method) {
             return false;
         }
-        if (exact != other.exact) {
+        if (!Objects.equals(path, other.path)) {
             return false;
         }
-        if (get != other.get) {
-            return false;
-        }
-        if (path == null) {
-            if (other.path != null) {
-                return false;
-            }
-        } else if (!path.equals(other.path)) {
-            return false;
-        }
-        if (pathRegex == null) {
-            if (other.pathRegex != null) {
-                return false;
-            }
-        } else if (!pathRegex.equals(other.pathRegex)) {
-            return false;
-        }
-        if (post != other.post) {
-            return false;
-        }
-        if (!Arrays.equals(produces, other.produces)) {
-            return false;
-        }
-        if (put != other.put) {
-            return false;
-        }
-        return true;
+        return Arrays.equals(produces, other.produces);
     }
 
     public String[] getConsumes() {
 
         return consumes;
+    }
+
+    /**
+     * Gets the VertX HTTP method.
+     *
+     * @return VertX HTTP method
+     */
+    public HttpMethod getMethod() {
+
+        return method;
     }
 
     /**
@@ -168,20 +143,10 @@ public class JaxRsPath implements
         final int prime = 31;
         int result = 1;
         result = prime * result + Arrays.hashCode(consumes);
-        result = prime * result + (delete ? 1231 : 1237);
-        result = prime * result + (exact ? 1231 : 1237);
-        result = prime * result + (get ? 1231 : 1237);
+        result = prime * result + (method == null ? 0 : method.hashCode());
         result = prime * result + (path == null ? 0 : path.hashCode());
-        result = prime * result + (pathRegex == null ? 0 : pathRegex.hashCode());
-        result = prime * result + (post ? 1231 : 1237);
         result = prime * result + Arrays.hashCode(produces);
-        result = prime * result + (put ? 1231 : 1237);
         return result;
-    }
-
-    public boolean isDelete() {
-
-        return delete;
     }
 
     /**
@@ -196,16 +161,7 @@ public class JaxRsPath implements
 
     public boolean isGet() {
 
-        return get;
+        return method == HttpMethod.GET;
     }
 
-    public boolean isPost() {
-
-        return post;
-    }
-
-    public boolean isPut() {
-
-        return put;
-    }
 }

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
@@ -1,0 +1,142 @@
+package net.trajano.ms.engine.jaxrs;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JaxRsPath implements
+    Comparable<JaxRsPath> {
+
+    /**
+     * Mime types that get consumed by the path. This is expected to be empty for
+     * GET requests.
+     */
+    private final String[] consumes;
+
+    private final boolean delete;
+
+    private final boolean exact;
+
+    /**
+     * Flag for GET and HEAD requests.
+     */
+    private final boolean get;
+
+    private final String path;
+
+    private final String pathRegex;
+
+    private final boolean post;
+
+    private final String[] produces;
+
+    private final boolean put;
+
+    public JaxRsPath(final String path,
+        final String[] consumes,
+        final String[] produces,
+        final boolean get,
+        final boolean post,
+        final boolean put,
+        final boolean delete) {
+
+        this.path = path;
+        this.consumes = consumes;
+        this.produces = produces;
+        this.get = get;
+        this.post = post;
+        this.put = put;
+        this.delete = delete;
+        final Pattern placeholderPattern = Pattern.compile("/\\{([^}]+)}");
+        final Pattern regexPlaceholderPattern = Pattern.compile("[-A-Za-z_0-9]+:\\s*(.+)");
+        final Matcher matcher = placeholderPattern.matcher(path);
+
+        final StringBuffer b = new StringBuffer();
+        while (matcher.find()) {
+            final Matcher m2 = regexPlaceholderPattern.matcher(matcher.group(1));
+            if (m2.matches()) {
+                matcher.appendReplacement(b, "/" + m2.group(1));
+            } else {
+                matcher.appendReplacement(b, "/[^/]+");
+            }
+        }
+        matcher.appendTail(b);
+        pathRegex = b.toString();
+        exact = pathRegex.equals(path);
+    }
+
+    /**
+     * Compares two JaxRsPath objects such that it is ordered by most specific and
+     * lowest level first. It sorts it in reverse by path. {@inheritDoc}
+     */
+    @Override
+    public int compareTo(final JaxRsPath o) {
+
+        if (exact && !o.exact) {
+            return -1;
+        } else if (!exact && o.exact) {
+            return 1;
+        }
+
+        return o.path.compareTo(path);
+    }
+
+    public String[] getConsumes() {
+
+        return consumes;
+    }
+
+    /**
+     * Gets the path that is specified in the JAX-RS classes.
+     *
+     * @return path
+     */
+    public String getPath() {
+
+        return path;
+    }
+
+    /**
+     * Gets the path that is suitable for the router.
+     *
+     * @return path regular expression
+     */
+    public String getPathRegex() {
+
+        return pathRegex;
+    }
+
+    public String[] getProduces() {
+
+        return produces;
+    }
+
+    public boolean isDelete() {
+
+        return delete;
+    }
+
+    /**
+     * Checks if the path is an exact one (i.e. no regex)
+     *
+     * @return exact path indicator
+     */
+    public boolean isExact() {
+
+        return exact;
+    }
+
+    public boolean isGet() {
+
+        return get;
+    }
+
+    public boolean isPost() {
+
+        return post;
+    }
+
+    public boolean isPut() {
+
+        return put;
+    }
+}

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
@@ -164,4 +164,15 @@ public class JaxRsPath implements
         return method == HttpMethod.GET;
     }
 
+    public boolean isNoProduces() {
+
+        return produces.length == 0;
+    }
+
+    @Override
+    public String toString() {
+
+        return "JaxRsPath [consumes=" + Arrays.toString(consumes) + ", exact=" + exact + ", method=" + method + ", path=" + path + ", pathRegex=" + pathRegex + ", produces=" + Arrays.toString(produces) + "]";
+    }
+
 }

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsPath.java
@@ -1,5 +1,6 @@
 package net.trajano.ms.engine.jaxrs;
 
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -80,6 +81,57 @@ public class JaxRsPath implements
         return o.path.compareTo(path);
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final JaxRsPath other = (JaxRsPath) obj;
+        if (!Arrays.equals(consumes, other.consumes)) {
+            return false;
+        }
+        if (delete != other.delete) {
+            return false;
+        }
+        if (exact != other.exact) {
+            return false;
+        }
+        if (get != other.get) {
+            return false;
+        }
+        if (path == null) {
+            if (other.path != null) {
+                return false;
+            }
+        } else if (!path.equals(other.path)) {
+            return false;
+        }
+        if (pathRegex == null) {
+            if (other.pathRegex != null) {
+                return false;
+            }
+        } else if (!pathRegex.equals(other.pathRegex)) {
+            return false;
+        }
+        if (post != other.post) {
+            return false;
+        }
+        if (!Arrays.equals(produces, other.produces)) {
+            return false;
+        }
+        if (put != other.put) {
+            return false;
+        }
+        return true;
+    }
+
     public String[] getConsumes() {
 
         return consumes;
@@ -108,6 +160,23 @@ public class JaxRsPath implements
     public String[] getProduces() {
 
         return produces;
+    }
+
+    @Override
+    public int hashCode() {
+
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(consumes);
+        result = prime * result + (delete ? 1231 : 1237);
+        result = prime * result + (exact ? 1231 : 1237);
+        result = prime * result + (get ? 1231 : 1237);
+        result = prime * result + (path == null ? 0 : path.hashCode());
+        result = prime * result + (pathRegex == null ? 0 : pathRegex.hashCode());
+        result = prime * result + (post ? 1231 : 1237);
+        result = prime * result + Arrays.hashCode(produces);
+        result = prime * result + (put ? 1231 : 1237);
+        return result;
     }
 
     public boolean isDelete() {

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
@@ -58,6 +58,7 @@ public class JaxRsRouter {
 
         final Reflections reflections = new Reflections(applicationClass);
         final String rootPath = Optional.ofNullable(applicationClass.getAnnotation(ApplicationPath.class)).map(ApplicationPath::value).orElse("/");
+        final JaxRsFailureHandler failureHandler = new JaxRsFailureHandler();
 
         final SortedSet<JaxRsPath> paths = new TreeSet<>();
         reflections.getTypesAnnotatedWith(Path.class).forEach(clazz -> {
@@ -81,7 +82,7 @@ public class JaxRsRouter {
             } else {
                 route = router.routeWithRegex(p.getMethod(), p.getPathRegex());
             }
-            route.consumes(consumes).produces(produces).handler(jaxRsHandler);
+            route.consumes(consumes).produces(produces).handler(jaxRsHandler).failureHandler(failureHandler);
 
         })));
         paths.stream().filter(p -> !p.isGet() && p.isNoProduces()).forEach(p -> stream(p.getConsumes()).forEach(consumes -> {
@@ -91,7 +92,7 @@ public class JaxRsRouter {
             } else {
                 route = router.routeWithRegex(p.getMethod(), p.getPathRegex());
             }
-            route.consumes(consumes).handler(jaxRsHandler);
+            route.consumes(consumes).handler(jaxRsHandler).failureHandler(failureHandler);
 
         }));
         paths.stream().filter(JaxRsPath::isGet).forEach(p -> stream(p.getProduces()).forEach(produces -> {
@@ -104,8 +105,8 @@ public class JaxRsRouter {
                 getRoute = router.getWithRegex(p.getPathRegex());
                 headRoute = router.headWithRegex(p.getPathRegex());
             }
-            getRoute.produces(produces).handler(jaxRsHandler);
-            headRoute.handler(jaxRsHandler);
+            getRoute.produces(produces).handler(jaxRsHandler).failureHandler(failureHandler);
+            headRoute.handler(jaxRsHandler).failureHandler(failureHandler);
             LOG.debug("path={}", p);
         }));
         paths.stream().filter(p -> p.isGet() && p.isNoProduces()).forEach(p -> {
@@ -118,8 +119,8 @@ public class JaxRsRouter {
                 getRoute = router.getWithRegex(p.getPathRegex());
                 headRoute = router.headWithRegex(p.getPathRegex());
             }
-            getRoute.handler(jaxRsHandler);
-            headRoute.handler(jaxRsHandler);
+            getRoute.handler(jaxRsHandler).failureHandler(failureHandler);
+            headRoute.handler(jaxRsHandler).failureHandler(failureHandler);
             LOG.debug("path={}", p);
         });
 

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
@@ -1,0 +1,103 @@
+package net.trajano.ms.engine.jaxrs;
+
+import static java.util.Arrays.stream;
+
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+
+import org.reflections.Reflections;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * This will take the JAX-RS annotated classes and create individual routes on a
+ * VertX router.
+ */
+public class JaxRsRouter {
+
+    public void register(final Class<? extends Application> applicationClass,
+        final Router router,
+        final Handler<RoutingContext> jaxRsHandler) {
+
+        final Reflections reflections = new Reflections(applicationClass);
+        final String rootPath = Optional.ofNullable(applicationClass.getAnnotation(ApplicationPath.class)).map(ApplicationPath::value).orElse("/");
+
+        final SortedSet<JaxRsPath> paths = new TreeSet<>();
+        reflections.getTypesAnnotatedWith(Path.class).forEach(clazz -> {
+            final String classPath = Optional.ofNullable(clazz.getAnnotation(Path.class)).map(Path::value).orElse("");
+            stream(clazz.getMethods()).filter(m -> m.getAnnotation(GET.class) != null
+                || m.getAnnotation(POST.class) != null
+                || m.getAnnotation(PUT.class) != null
+                || m.getAnnotation(DELETE.class) != null).forEach(m -> {
+                    final String path = Optional.ofNullable(m.getAnnotation(Path.class)).map(Path::value).orElse("");
+                    final String[] consumes = Optional.ofNullable(m.getAnnotation(Consumes.class)).map(Consumes::value).orElse(new String[0]);
+                    final String[] produces = Optional.ofNullable(m.getAnnotation(Produces.class)).map(Produces::value).orElse(new String[0]);
+
+                    final boolean get = m.getAnnotation(GET.class) != null;
+                    final boolean post = m.getAnnotation(POST.class) != null;
+                    final boolean put = m.getAnnotation(PUT.class) != null;
+                    final boolean delete = m.getAnnotation(DELETE.class) != null;
+                    paths.add(new JaxRsPath(rootPath + classPath + path, consumes, produces, get, post, put, delete));
+                });
+        });
+        paths.stream().filter(p -> !p.isGet()).forEach(p -> stream(p.getConsumes()).forEach(consumes -> stream(p.getProduces()).forEach(produces -> {
+            final Route route;
+            if (p.isPost()) {
+                if (p.isExact()) {
+                    route = router.post(p.getPath());
+                } else {
+                    route = router.postWithRegex(p.getPathRegex());
+                }
+            } else if (p.isPut()) {
+                if (p.isExact()) {
+                    route = router.put(p.getPath());
+                } else {
+                    route = router.putWithRegex(p.getPathRegex());
+                }
+            } else if (p.isDelete()) {
+                if (p.isExact()) {
+                    route = router.delete(p.getPath());
+                } else {
+                    route = router.deleteWithRegex(p.getPathRegex());
+                }
+            } else {
+                throw new IllegalStateException("JaxRsPath=" + p + " does not have a HTTP Method active");
+            }
+            route.consumes(consumes).produces(produces).handler(jaxRsHandler);
+
+        })));
+        paths.stream().filter(p -> p.isGet()).forEach(p -> stream(p.getProduces()).forEach(produces -> {
+            final Route getRoute;
+            final Route headRoute;
+            if (p.isGet()) {
+                if (p.isExact()) {
+                    getRoute = router.get(p.getPath());
+                    headRoute = router.head(p.getPath());
+                } else {
+                    getRoute = router.getWithRegex(p.getPathRegex());
+                    headRoute = router.head(p.getPathRegex());
+                }
+            } else {
+                throw new IllegalStateException("JaxRsPath=" + p + " does not have a HTTP Method active");
+            }
+            getRoute.produces(produces).handler(jaxRsHandler);
+            headRoute.handler(jaxRsHandler);
+
+        }));
+
+    }
+}

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
@@ -56,7 +56,7 @@ public class JaxRsRouter {
         final Handler<RoutingContext> jaxRsHandler) {
 
         final Reflections reflections = new Reflections(applicationClass);
-        final String rootPath = Optional.ofNullable(applicationClass.getAnnotation(ApplicationPath.class)).map(ApplicationPath::value).orElse("/");
+        final String rootPath = Optional.ofNullable(applicationClass.getAnnotation(ApplicationPath.class)).map(ApplicationPath::value).orElse("");
         final JaxRsFailureHandler failureHandler = new JaxRsFailureHandler();
 
         final SortedSet<JaxRsPath> paths = new TreeSet<>();
@@ -74,7 +74,10 @@ public class JaxRsRouter {
 
                 });
         });
-        paths.forEach(p -> p.apply(router, jaxRsHandler, failureHandler));
+        paths.forEach(p -> {
+            p.apply(router, jaxRsHandler, failureHandler);
+            LOG.debug("route={}", p);
+        });
 
     }
 }

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
@@ -80,7 +80,7 @@ public class JaxRsRouter {
             route.consumes(consumes).produces(produces).handler(jaxRsHandler);
 
         })));
-        paths.stream().filter(p -> p.isGet()).forEach(p -> stream(p.getProduces()).forEach(produces -> {
+        paths.stream().filter(JaxRsPath::isGet).forEach(p -> stream(p.getProduces()).forEach(produces -> {
             final Route getRoute;
             final Route headRoute;
             if (p.isGet()) {

--- a/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
+++ b/ms-engine-spring-jaxrs/src/main/java/net/trajano/ms/engine/jaxrs/JaxRsRouter.java
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Component;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
@@ -75,54 +74,7 @@ public class JaxRsRouter {
 
                 });
         });
-        paths.stream().filter(p -> !p.isGet()).forEach(p -> stream(p.getConsumes()).forEach(consumes -> stream(p.getProduces()).forEach(produces -> {
-            final Route route;
-            if (p.isExact()) {
-                route = router.route(p.getMethod(), p.getPath());
-            } else {
-                route = router.routeWithRegex(p.getMethod(), p.getPathRegex());
-            }
-            route.consumes(consumes).produces(produces).handler(jaxRsHandler).failureHandler(failureHandler);
-
-        })));
-        paths.stream().filter(p -> !p.isGet() && p.isNoProduces()).forEach(p -> stream(p.getConsumes()).forEach(consumes -> {
-            final Route route;
-            if (p.isExact()) {
-                route = router.route(p.getMethod(), p.getPath());
-            } else {
-                route = router.routeWithRegex(p.getMethod(), p.getPathRegex());
-            }
-            route.consumes(consumes).handler(jaxRsHandler).failureHandler(failureHandler);
-
-        }));
-        paths.stream().filter(JaxRsPath::isGet).forEach(p -> stream(p.getProduces()).forEach(produces -> {
-            final Route getRoute;
-            final Route headRoute;
-            if (p.isExact()) {
-                getRoute = router.get(p.getPath());
-                headRoute = router.head(p.getPath());
-            } else {
-                getRoute = router.getWithRegex(p.getPathRegex());
-                headRoute = router.headWithRegex(p.getPathRegex());
-            }
-            getRoute.produces(produces).handler(jaxRsHandler).failureHandler(failureHandler);
-            headRoute.handler(jaxRsHandler).failureHandler(failureHandler);
-            LOG.debug("path={}", p);
-        }));
-        paths.stream().filter(p -> p.isGet() && p.isNoProduces()).forEach(p -> {
-            final Route getRoute;
-            final Route headRoute;
-            if (p.isExact()) {
-                getRoute = router.get(p.getPath());
-                headRoute = router.head(p.getPath());
-            } else {
-                getRoute = router.getWithRegex(p.getPathRegex());
-                headRoute = router.headWithRegex(p.getPathRegex());
-            }
-            getRoute.handler(jaxRsHandler).failureHandler(failureHandler);
-            headRoute.handler(jaxRsHandler).failureHandler(failureHandler);
-            LOG.debug("path={}", p);
-        });
+        paths.forEach(p -> p.apply(router, jaxRsHandler, failureHandler));
 
     }
 }

--- a/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/sample/SampleApp.java
+++ b/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/sample/SampleApp.java
@@ -1,0 +1,9 @@
+package net.trajano.ms.engine.jaxrs.sample;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/app")
+public class SampleApp extends Application {
+
+}

--- a/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/sample/SampleResource.java
+++ b/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/sample/SampleResource.java
@@ -52,8 +52,14 @@ public class SampleResource {
     }
 
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
     public Response root() {
+
+        return null;
+    }
+
+    @GET
+    @Path("/{blah}")
+    public Response rootRegex(@PathParam("blah") final String blah) {
 
         return null;
     }

--- a/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/sample/SampleResource.java
+++ b/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/sample/SampleResource.java
@@ -1,0 +1,61 @@
+package net.trajano.ms.engine.jaxrs.sample;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/res")
+public class SampleResource {
+
+    @DELETE
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/delete")
+    public Response delete(final String hello) {
+
+        return null;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/post")
+    public Response post(final String hello) {
+
+        return null;
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/put")
+    public Response put(final String hello) {
+
+        return null;
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/put/{id}")
+    public Response putRegex(@PathParam("id") final String id,
+        final String hello) {
+
+        return null;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response root() {
+
+        return null;
+    }
+
+}

--- a/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/test/JaxRsRouterTest.java
+++ b/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/test/JaxRsRouterTest.java
@@ -1,0 +1,24 @@
+package net.trajano.ms.engine.jaxrs.test;
+
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import net.trajano.ms.engine.jaxrs.JaxRsRouter;
+import net.trajano.ms.engine.jaxrs.sample.SampleApp;
+
+public class JaxRsRouterTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRegister() throws Exception {
+
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        final Vertx vertx = Vertx.vertx();
+        final Router router = Router.router(vertx);
+        jaxRsRouter.register(SampleApp.class, router, mock(Handler.class));
+    }
+}

--- a/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/test/PathPlaceholderTest.java
+++ b/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/test/PathPlaceholderTest.java
@@ -1,26 +1,54 @@
 package net.trajano.ms.engine.jaxrs.test;
 
-import net.trajano.ms.engine.jaxrs.JaxRsPath;
-import org.junit.Test;
-
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.vertx.core.http.HttpMethod;
+import net.trajano.ms.engine.jaxrs.JaxRsPath;
 
 public class PathPlaceholderTest {
 
     @Test
     public void testExact() {
 
-        JaxRsPath path = new JaxRsPath("/exact", new String[0], new String[0], true, true, true, true);
+        final JaxRsPath path = new JaxRsPath("/exact", new String[0], new String[0], HttpMethod.POST);
         assertTrue(path.isExact());
         assertEquals(path.getPath(), path.getPathRegex());
     }
 
     @Test
+    public void testOrder() {
+
+        final JaxRsPath path1 = new JaxRsPath("/exact/{id}/foo/{x}", new String[0], new String[0], HttpMethod.PUT);
+        final JaxRsPath path2 = new JaxRsPath("/exact/{id}/foo", new String[0], new String[0], HttpMethod.PUT);
+        final JaxRsPath path3 = new JaxRsPath("/exact/abc/foo", new String[0], new String[0], HttpMethod.PUT);
+        final JaxRsPath path4 = new JaxRsPath("/exact/abc/foo/{x}", new String[0], new String[0], HttpMethod.PUT);
+
+        final List<JaxRsPath> list = Arrays.asList(path1, path2, path3, path4);
+        Collections.sort(list);
+        assertEquals(Arrays.asList(path3, path1, path2, path4), list);
+
+    }
+
+    @Test
+    public void testRegexPlaceholder() {
+
+        final JaxRsPath path = new JaxRsPath("/exact/{id}/foo/{x: [abc][0-9]+}", null, new String[0], HttpMethod.GET);
+        assertFalse(path.isExact());
+        assertEquals("/exact/[^/]+/foo/[abc][0-9]+", path.getPathRegex());
+    }
+
+    @Test
     public void testSimplePlaceholder() {
 
-        JaxRsPath path = new JaxRsPath("/exact/{id}", new String[0], new String[0], true, true, true, true);
+        final JaxRsPath path = new JaxRsPath("/exact/{id}", new String[0], new String[0], HttpMethod.POST);
         assertFalse(path.isExact());
         assertEquals("/exact/[^/]+", path.getPathRegex());
     }
@@ -28,7 +56,7 @@ public class PathPlaceholderTest {
     @Test
     public void testSimplePlaceholder2() {
 
-        JaxRsPath path = new JaxRsPath("/exact/{id}/foo", new String[0], new String[0], true, true, true, true);
+        final JaxRsPath path = new JaxRsPath("/exact/{id}/foo", new String[0], new String[0], HttpMethod.POST);
         assertFalse(path.isExact());
         assertEquals("/exact/[^/]+/foo", path.getPathRegex());
     }
@@ -36,16 +64,8 @@ public class PathPlaceholderTest {
     @Test
     public void testSimplePlaceholder3() {
 
-        JaxRsPath path = new JaxRsPath("/exact/{id}/foo/{x}", new String[0], new String[0], true, true, true, true);
+        final JaxRsPath path = new JaxRsPath("/exact/{id}/foo/{x}", new String[0], new String[0], HttpMethod.PUT);
         assertFalse(path.isExact());
         assertEquals("/exact/[^/]+/foo/[^/]+", path.getPathRegex());
-    }
-
-    @Test
-    public void testRegexPlaceholder() {
-
-        JaxRsPath path = new JaxRsPath("/exact/{id}/foo/{x: [abc][0-9]+}", new String[0], new String[0], true, true, true, true);
-        assertFalse(path.isExact());
-        assertEquals("/exact/[^/]+/foo/[abc][0-9]+", path.getPathRegex());
     }
 }

--- a/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/test/PathPlaceholderTest.java
+++ b/ms-engine-spring-jaxrs/src/test/java/net/trajano/ms/engine/jaxrs/test/PathPlaceholderTest.java
@@ -1,0 +1,51 @@
+package net.trajano.ms.engine.jaxrs.test;
+
+import net.trajano.ms.engine.jaxrs.JaxRsPath;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+public class PathPlaceholderTest {
+
+    @Test
+    public void testExact() {
+
+        JaxRsPath path = new JaxRsPath("/exact", new String[0], new String[0], true, true, true, true);
+        assertTrue(path.isExact());
+        assertEquals(path.getPath(), path.getPathRegex());
+    }
+
+    @Test
+    public void testSimplePlaceholder() {
+
+        JaxRsPath path = new JaxRsPath("/exact/{id}", new String[0], new String[0], true, true, true, true);
+        assertFalse(path.isExact());
+        assertEquals("/exact/[^/]+", path.getPathRegex());
+    }
+
+    @Test
+    public void testSimplePlaceholder2() {
+
+        JaxRsPath path = new JaxRsPath("/exact/{id}/foo", new String[0], new String[0], true, true, true, true);
+        assertFalse(path.isExact());
+        assertEquals("/exact/[^/]+/foo", path.getPathRegex());
+    }
+
+    @Test
+    public void testSimplePlaceholder3() {
+
+        JaxRsPath path = new JaxRsPath("/exact/{id}/foo/{x}", new String[0], new String[0], true, true, true, true);
+        assertFalse(path.isExact());
+        assertEquals("/exact/[^/]+/foo/[^/]+", path.getPathRegex());
+    }
+
+    @Test
+    public void testRegexPlaceholder() {
+
+        JaxRsPath path = new JaxRsPath("/exact/{id}/foo/{x: [abc][0-9]+}", new String[0], new String[0], true, true, true, true);
+        assertFalse(path.isExact());
+        assertEquals("/exact/[^/]+/foo/[abc][0-9]+", path.getPathRegex());
+    }
+}

--- a/ms-engine/pom.xml
+++ b/ms-engine/pom.xml
@@ -27,6 +27,10 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>ms-engine-spring-jaxrs</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/ms-engine/src/main/java/net/trajano/ms/engine/SpringJaxRsHandler.java
+++ b/ms-engine/src/main/java/net/trajano/ms/engine/SpringJaxRsHandler.java
@@ -210,6 +210,7 @@ public class SpringJaxRsHandler implements
                     try {
                         dispatcher.invokePropagateNotFound(request,
                             response);
+                        context.response().end();
                         future.complete();
                     } finally {
                         ResteasyProviderFactory.clearContextData();
@@ -224,10 +225,6 @@ public class SpringJaxRsHandler implements
                             context.next();
                         } else {
                             context.fail(wae);
-                        }
-                    } else {
-                        if (!context.response().ended()) {
-                            context.response().end();
                         }
                     }
                 });

--- a/ms-engine/src/main/java/net/trajano/ms/engine/SpringJaxRsHandler.java
+++ b/ms-engine/src/main/java/net/trajano/ms/engine/SpringJaxRsHandler.java
@@ -51,6 +51,7 @@ import net.trajano.ms.engine.internal.spring.CdiScopeMetadataResolver;
 import net.trajano.ms.engine.internal.spring.SpringConfiguration;
 import net.trajano.ms.engine.internal.spring.VertxRequestContextFilter;
 import net.trajano.ms.engine.jaxrs.CommonObjectMapperProvider;
+import net.trajano.ms.engine.jaxrs.JaxRsRouter;
 import net.trajano.ms.engine.jaxrs.WebApplicationExceptionMapper;
 
 public class SpringJaxRsHandler implements
@@ -67,7 +68,9 @@ public class SpringJaxRsHandler implements
      * @param applicationClasses
      *            application classes
      * @return the handlers
+     * @deprecated use {@link JaxRsRouter}
      */
+    @Deprecated
     @SafeVarargs
     public static SpringJaxRsHandler[] multipleRegisterToRouter(final Router router,
         final Class<? extends Application>... applicationClasses) {
@@ -86,7 +89,9 @@ public class SpringJaxRsHandler implements
      * @param applicationClasses
      *            application classes
      * @return the handlers
+     * @deprecated use {@link JaxRsRouter}
      */
+    @Deprecated
     @SafeVarargs
     public static SpringJaxRsHandler[] multipleRegisterToRouter(final Router router,
         final ConfigurableApplicationContext baseApplicationContext,
@@ -138,7 +143,9 @@ public class SpringJaxRsHandler implements
      * @param applicationClass
      *            application class
      * @return the handler
+     * @deprecated use {@link JaxRsRouter}
      */
+    @Deprecated
     public static SpringJaxRsHandler registerToRouter(final Router router,
         final Class<? extends Application> applicationClass) {
 
@@ -380,7 +387,7 @@ public class SpringJaxRsHandler implements
     /**
      * Get the JAX-RS Client that is present in the vertx context or create a new
      * one.
-     * 
+     *
      * @param vertx
      *            vertx
      * @return JAX-RS client.

--- a/ms-engine/src/test/java/net/trajano/ms/engine/sample/EngineSampleMain.java
+++ b/ms-engine/src/test/java/net/trajano/ms/engine/sample/EngineSampleMain.java
@@ -14,6 +14,7 @@ import io.vertx.ext.web.Router;
 import net.trajano.ms.engine.ManifestHandler;
 import net.trajano.ms.engine.SpringJaxRsHandler;
 import net.trajano.ms.engine.SwaggerHandler;
+import net.trajano.ms.engine.jaxrs.JaxRsRouter;
 
 @Configuration
 public class EngineSampleMain extends AbstractVerticle {
@@ -48,7 +49,8 @@ public class EngineSampleMain extends AbstractVerticle {
         final HttpServer http = vertx.createHttpServer(httpServerOptions);
 
         SwaggerHandler.registerToRouter(router, MyApp.class);
-        requestHandler = SpringJaxRsHandler.registerToRouter(router, MyApp.class);
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        jaxRsRouter.register(MyApp.class, router, new SpringJaxRsHandler(MyApp.class));
         ManifestHandler.registerToRouter(router);
 
         http.requestHandler(req -> router.accept(req)).listen(res -> {

--- a/ms-engine/src/test/java/net/trajano/ms/engine/test/SpringJaxRsHandlerTest.java
+++ b/ms-engine/src/test/java/net/trajano/ms/engine/test/SpringJaxRsHandlerTest.java
@@ -1,6 +1,7 @@
 package net.trajano.ms.engine.test;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -17,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import io.netty.util.AsciiString;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -28,6 +30,7 @@ import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
 import net.trajano.ms.engine.SpringJaxRsHandler;
+import net.trajano.ms.engine.jaxrs.JaxRsRouter;
 import net.trajano.ms.engine.sample.MyApp;
 
 @RunWith(VertxUnitRunner.class)
@@ -40,7 +43,8 @@ public class SpringJaxRsHandlerTest {
     public void test400(final TestContext testContext) throws Exception {
 
         final Router router = Router.router(rule.vertx());
-        SpringJaxRsHandler.registerToRouter(router, MyApp.class);
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        jaxRsRouter.register(MyApp.class, router, new SpringJaxRsHandler(MyApp.class));
 
         final HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.absoluteURI()).thenReturn("http://test.trajano.net/api/hello/400");
@@ -74,7 +78,8 @@ public class SpringJaxRsHandlerTest {
     public void test404(final TestContext testContext) throws Exception {
 
         final Router router = Router.router(rule.vertx());
-        SpringJaxRsHandler.registerToRouter(router, MyApp.class);
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        jaxRsRouter.register(MyApp.class, router, new SpringJaxRsHandler(MyApp.class));
 
         final HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.absoluteURI()).thenReturn("http://test.trajano.net/api/nothello");
@@ -85,6 +90,7 @@ public class SpringJaxRsHandlerTest {
 
         final HttpServerResponse response = mock(HttpServerResponse.class);
         when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.putHeader(any(AsciiString.class), anyString())).thenReturn(response);
         when(response.headers()).thenReturn(new VertxHttpHeaders());
 
         final Async async = testContext.async();
@@ -92,21 +98,22 @@ public class SpringJaxRsHandlerTest {
 
             async.complete();
             return null;
-        }).when(response).end("Not Found");
+        }).when(response).end(anyString());
         when(serverRequest.response()).thenReturn(response);
 
         router.accept(serverRequest);
         async.await();
 
         verify(response, times(1)).setStatusCode(404);
-        verify(response, times(1)).end("Not Found");
+        verify(response, times(1)).end(anyString());
     }
 
     @Test
     public void test404Internal(final TestContext testContext) throws Exception {
 
         final Router router = Router.router(rule.vertx());
-        SpringJaxRsHandler.registerToRouter(router, MyApp.class);
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        jaxRsRouter.register(MyApp.class, router, new SpringJaxRsHandler(MyApp.class));
 
         final HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.absoluteURI()).thenReturn("http://test.trajano.net/api/hello/404");
@@ -117,6 +124,7 @@ public class SpringJaxRsHandlerTest {
 
         final HttpServerResponse response = mock(HttpServerResponse.class);
         when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.putHeader(any(AsciiString.class), anyString())).thenReturn(response);
         when(response.headers()).thenReturn(new VertxHttpHeaders());
 
         final Async async = testContext.async();
@@ -140,7 +148,8 @@ public class SpringJaxRsHandlerTest {
     public void test500(final TestContext testContext) throws Exception {
 
         final Router router = Router.router(rule.vertx());
-        SpringJaxRsHandler.registerToRouter(router, MyApp.class);
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        jaxRsRouter.register(MyApp.class, router, new SpringJaxRsHandler(MyApp.class));
 
         final HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.absoluteURI()).thenReturn("http://test.trajano.net/api/hello/cough");
@@ -178,7 +187,8 @@ public class SpringJaxRsHandlerTest {
     public void testHandler(final TestContext testContext) throws Exception {
 
         final Router router = Router.router(rule.vertx());
-        SpringJaxRsHandler.registerToRouter(router, MyApp.class);
+        final JaxRsRouter jaxRsRouter = new JaxRsRouter();
+        jaxRsRouter.register(MyApp.class, router, new SpringJaxRsHandler(MyApp.class));
 
         final HttpServerRequest serverRequest = mock(HttpServerRequest.class);
         when(serverRequest.absoluteURI()).thenReturn("http://test.trajano.net/api/hello");

--- a/ms-engine/src/test/java/net/trajano/ms/engine/test/SpringJaxRsHandlerTest.java
+++ b/ms-engine/src/test/java/net/trajano/ms/engine/test/SpringJaxRsHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -163,14 +164,13 @@ public class SpringJaxRsHandlerTest {
         when(response.headers()).thenReturn(new VertxHttpHeaders());
 
         final Async async = testContext.async();
-        when(response.write(Matchers.any(Buffer.class))).then(invocation -> {
+        when(response.write(Matchers.any(Buffer.class))).thenReturn(response);
 
-            try {
-                return response;
-            } finally {
-                async.complete();
-            }
-        });
+        doAnswer(i -> {
+            async.complete();
+            return null;
+        }).when(response).end();
+
         when(serverRequest.response()).thenReturn(response);
 
         router.accept(serverRequest);

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>ms-engine-spring-jaxrs</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>ms-gateway</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Instead of relying wholly on the handler to route, add it to the router.  That way there will be less chance of "spillage"