### PR TITLE
(update) spring boot 2.0.0.RELEASE

### DIFF
--- a/ms-common-impl/src/main/java/net/trajano/ms/vertx/VertxMicroserviceEngine.java
+++ b/ms-common-impl/src/main/java/net/trajano/ms/vertx/VertxMicroserviceEngine.java
@@ -67,7 +67,7 @@ public class VertxMicroserviceEngine implements
      * Sets the system properties and sets up the logger. {@inheritDoc}
      */
     @Override
-    public Object[] bootstrap() {
+    public Class<?>[] bootstrap() {
 
         System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory");
 
@@ -76,7 +76,7 @@ public class VertxMicroserviceEngine implements
             System.setProperty("logging.config", logbackFile.getAbsolutePath());
         }
 
-        return new Object[] {
+        return new Class<?>[] {
             VertxConfig.class,
             VertxMicroserviceEngine.class
         };

--- a/ms-common/pom.xml
+++ b/ms-common/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>
@@ -122,11 +122,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
@@ -152,7 +147,7 @@
             <inherited>false</inherited>
             <configuration>
               <rules>
-                <dependencyConvergence />
+                <dependencyConvergence/>
               </rules>
             </configuration>
           </execution>

--- a/ms-common/src/main/java/net/trajano/ms/Microservice.java
+++ b/ms-common/src/main/java/net/trajano/ms/Microservice.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Application;
 
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 
 import net.trajano.ms.spi.MicroserviceEngine;
 
@@ -86,7 +87,7 @@ public class Microservice {
         System.arraycopy(bootstrapObjects, 0, sources, extraSources.length, bootstrapObjects.length);
 
         final SpringApplication springApplication = new SpringApplication(sources);
-        springApplication.setWebEnvironment(false);
+        springApplication.setWebApplicationType(WebApplicationType.NONE);
         springApplication
             .setBannerMode(Mode.OFF);
         springApplication.run(args);

--- a/ms-common/src/main/java/net/trajano/ms/Microservice.java
+++ b/ms-common/src/main/java/net/trajano/ms/Microservice.java
@@ -79,8 +79,8 @@ public class Microservice {
         }
         Microservice.applicationClass = applicationClass;
 
-        final Object[] bootstrapObjects = microserviceEngine.bootstrap();
-        final Object[] sources = new Object[extraSources.length + bootstrapObjects.length];
+        final Class<?>[] bootstrapObjects = microserviceEngine.bootstrap();
+        final Class<?>[] sources = new Class<?>[extraSources.length + bootstrapObjects.length];
 
         System.arraycopy(extraSources, 0, sources, 0, extraSources.length);
         System.arraycopy(bootstrapObjects, 0, sources, extraSources.length, bootstrapObjects.length);

--- a/ms-common/src/main/java/net/trajano/ms/spi/MicroserviceEngine.java
+++ b/ms-common/src/main/java/net/trajano/ms/spi/MicroserviceEngine.java
@@ -4,11 +4,11 @@ public interface MicroserviceEngine {
 
     /**
      * Performs the initialization of the microservice engine and returns an array
-     * of objects that would be used to bootstrap Spring.
+     * of classes that would be used to bootstrap Spring.
      *
-     * @return starting context objects.
+     * @return starting context classes.
      */
-    Object[] bootstrap();
+    Class<?>[] bootstrap();
 
     /**
      * Gets the host name of where the engine is running. This may be

--- a/ms-common/src/test/java/net/trajano/ms/common/test/BootstrapTest.java
+++ b/ms-common/src/test/java/net/trajano/ms/common/test/BootstrapTest.java
@@ -37,7 +37,7 @@ public class BootstrapTest {
     public void bootstrapTest() throws Exception {
 
         final MicroserviceEngine microserviceEngine = Mockito.mock(MicroserviceEngine.class);
-        Mockito.when(microserviceEngine.bootstrap()).thenReturn(new Object[] {
+        Mockito.when(microserviceEngine.bootstrap()).thenReturn(new Class<?>[] {
             MyApp.class
         });
         new TestMicroservice().setEngines(microserviceEngine);
@@ -49,7 +49,7 @@ public class BootstrapTest {
     public void doubleRunTest() throws Exception {
 
         final MicroserviceEngine microserviceEngine = Mockito.mock(MicroserviceEngine.class);
-        Mockito.when(microserviceEngine.bootstrap()).thenReturn(new Object[] {
+        Mockito.when(microserviceEngine.bootstrap()).thenReturn(new Class<?>[] {
             MyApp.class
         });
         new TestMicroservice().setApplicationAndEngines(MyApp.class, microserviceEngine);

--- a/ms-engine/pom.xml
+++ b/ms-engine/pom.xml
@@ -187,6 +187,12 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <version>${vertx.version}</version>
       <scope>test</scope>

--- a/ms-gateway/pom.xml
+++ b/ms-gateway/pom.xml
@@ -77,6 +77,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>net.trajano.commons</groupId>
       <artifactId>commons-testing</artifactId>
       <version>2.1.0</version>

--- a/ms-gateway/src/main/java/net/trajano/ms/gateway/GatewayMS.java
+++ b/ms-gateway/src/main/java/net/trajano/ms/gateway/GatewayMS.java
@@ -7,6 +7,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -28,7 +29,7 @@ public class GatewayMS {
 
         final SpringApplication application = new SpringApplication(GatewayMS.class);
         application.setBannerMode(Mode.OFF);
-        application.setWebEnvironment(false);
+        application.setWebApplicationType(WebApplicationType.NONE);
         application.run(args);
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <linkcheck.skip>true</linkcheck.skip>
     <repo.id>app-ms</repo.id>
     <slf4j.version>1.7.16</slf4j.version>
-    <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
+    <spring.boot.version>2.0.0.RELEASE</spring.boot.version>
     <vertx.version>3.5.1</vertx.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Use the new version of spring boot.  This will change the SPI because
Spring boot now uses Class<?>[] to boostrap rather than Object[].

It also upgrades Mockito to 2.x which requires an additional test scope
library for Vert.X mock testing.